### PR TITLE
Fix critical bug where entities are not deleted AT ALL

### DIFF
--- a/src/protocolsupportlegacysupport/features/hologram/HologramHandler.java
+++ b/src/protocolsupportlegacysupport/features/hologram/HologramHandler.java
@@ -2,6 +2,7 @@ package protocolsupportlegacysupport.features.hologram;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 
 import org.bukkit.Bukkit;
@@ -85,13 +86,19 @@ public class HologramHandler extends AbstractFeature<Void> implements Listener {
 					return initArmorStand(getTracker(connection), packet.getIntegers().read(0), packet.getDoubles());
 				});
 				registerHandler(PacketType.Play.Server.ENTITY_DESTROY, (connection, packet) -> {
-					int entityId = packet.getIntegers().read(0);
+					List<Integer> entityIds = new ArrayList<>(packet.getIntLists().read(0));
 					ArmorStandTracker tracker = getTracker(connection);
-					if (!tracker.has(entityId)) {
-						return null;
-					}
 					List<PacketContainer> packets = new ArrayList<>();
-					getTracker(connection).destroy(packets, entityId);
+					Iterator<Integer> entityIdsIter = entityIds.iterator();
+					while (entityIdsIter.hasNext()) {
+						Integer entityId = entityIdsIter.next();
+						if (tracker.has(entityId)) {
+							tracker.destroy(packets, entityId);
+						}
+					}
+					if (!entityIds.isEmpty()) {
+						packets.add(PacketUtils.createEntityDestroyPacket(entityIds));
+					}
 					return packets;
 				});
 				registerHandler(PacketType.Play.Server.ENTITY_METADATA, (connection, packet) -> {

--- a/src/protocolsupportlegacysupport/features/hologram/HologramHandler.java
+++ b/src/protocolsupportlegacysupport/features/hologram/HologramHandler.java
@@ -2,7 +2,6 @@ package protocolsupportlegacysupport.features.hologram;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.bukkit.Bukkit;
@@ -86,21 +85,13 @@ public class HologramHandler extends AbstractFeature<Void> implements Listener {
 					return initArmorStand(getTracker(connection), packet.getIntegers().read(0), packet.getDoubles());
 				});
 				registerHandler(PacketType.Play.Server.ENTITY_DESTROY, (connection, packet) -> {
-					List<Integer> entityIds = new ArrayList<>(packet.getIntLists().read(0));
+					int entityId = packet.getIntegers().read(0);
 					ArmorStandTracker tracker = getTracker(connection);
+					if (!tracker.has(entityId)) {
+						return null;
+					}
 					List<PacketContainer> packets = new ArrayList<>();
-					Iterator<Integer> entityIdsIter = entityIds.iterator();
-					while (entityIdsIter.hasNext()) {
-						Integer entityId = entityIdsIter.next();
-						if (tracker.has(entityId)) {
-							tracker.destroy(packets, entityId);
-						} else {
-							entityIdsIter.remove();
-						}
-					}
-					if (!entityIds.isEmpty()) {
-						packets.add(PacketUtils.createEntityDestroyPacket(entityIds));
-					}
+					getTracker(connection).destroy(packets, entityId);
 					return packets;
 				});
 				registerHandler(PacketType.Play.Server.ENTITY_METADATA, (connection, packet) -> {


### PR DESCRIPTION
**BUG DETAILS:**

(I have also observed this on vanilla Minecraft 1.5.2, so it is not the fact that it is in a browser. Server is 1.17.1, and the problem only occurs with this plugin. (I am not asking for support on the outdated ProtocolSupport 1.17.1; just this))

Server plugins (the ones that are not custom (if you cannot reproduce with these plugins alone, I will share custom plugins)): Essentials, FastAsyncWorldEdit (WorldEdit), Geyser-Spigot, ProtocolLib, ProtocolSupport, ProtocolSupportLegacySupport, ViaBackwards, ViaRewind, ViaVersion

Server version: Paper 1.17.1 (a fork of it, anyways; the fork simply has anti chunkban patches and a few others. not the cause of the bug.)

See video:

https://user-images.githubusercontent.com/24785136/165888813-a1194c2f-637d-469f-acf0-b0b67901d134.mp4
